### PR TITLE
Implement LineCounter class with Argument Parsing

### DIFF
--- a/ccwc/ccwc.py
+++ b/ccwc/ccwc.py
@@ -1,4 +1,5 @@
 import argparse
+import codecs
 from abc import ABC, abstractmethod
 
 
@@ -20,10 +21,25 @@ class ByteCounter(Counter):
         return byte_count
 
 
+class LineCounter(Counter):
+    def count(self, file_contents):
+        line_count = 0
+        try:
+            with open(file_contents, "r", encoding='utf-8') as file:
+                file_data = file.readlines()
+                line_count = len(file_data)
+        except FileNotFoundError:
+            print(f"Error: File not found: {file_contents}")
+        except UnicodeDecodeError:
+            print(f"Error: Unable to decode the file using 'utf-8' encoding.")
+        return line_count
+
+
 class CLI:
     def __init__(self):
         self.parser = argparse.ArgumentParser(description="Byte Counter Tool")
         self.parser.add_argument("-c", nargs='?', const="-", default=None, help="File to count bytes in")
+        self.parser.add_argument("-l", nargs='?', const="-", default=None, help="File to count lines in")
 
     def parse_args(self):
         args = self.parser.parse_args()
@@ -38,6 +54,12 @@ class CLI:
                 byte_counter = ByteCounter()
                 total_bytes = byte_counter.count(args.c)
                 print(f"Number of bytes: {total_bytes}")
+
+        if arg_provided_by_user:
+            if args.l is not None:
+                line_counter = LineCounter()
+                total_lines = line_counter.count(args.l)
+                print(f"Number of lines: {total_lines}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description:
- Added LineCounter class to count the number of lines in test file.
- Implemented argument parsing using argparse for file input.
- The '-l' option is supported, and it now counts lines in the specified file.
- Added Error handling for FileNotFoundError and UnicodeDecodeError.
- Add encoding='utf-8' parameter from the open() function to enable correct reading of the file.

**Output:** 

![image](https://github.com/Ebi27/ccwc-unix/assets/94403217/a3085dbd-bb2b-46e7-afaf-c29baf72c73a)

