### PR TITLE
Implement WordCounter class with Argument Parsing

### DIFF
--- a/ccwc/ccwc.py
+++ b/ccwc/ccwc.py
@@ -1,5 +1,4 @@
 import argparse
-import codecs
 from abc import ABC, abstractmethod
 
 
@@ -25,7 +24,7 @@ class LineCounter(Counter):
     def count(self, file_contents):
         line_count = 0
         try:
-            with open(file_contents, "r", encoding='utf-8') as file:
+            with open(file_contents, 'r', encoding='utf-8') as file:
                 file_data = file.readlines()
                 line_count = len(file_data)
         except FileNotFoundError:
@@ -35,11 +34,27 @@ class LineCounter(Counter):
         return line_count
 
 
+class WordCounter(Counter):
+    def count(self, file_contents):
+        word_count = 0
+        try:
+            with open(file_contents, 'r', encoding='utf-8') as file:
+                file_data = file.read()
+                words = file_data.split()
+                word_count = len(words)
+        except FileNotFoundError:
+            print(f"Error: File not found: {file_contents}")
+        except UnicodeDecodeError:
+            print(f"Error: Unable to decode the file using 'utf-8' encoding.")
+        return word_count
+
+
 class CLI:
     def __init__(self):
         self.parser = argparse.ArgumentParser(description="Byte Counter Tool")
         self.parser.add_argument("-c", nargs='?', const="-", default=None, help="File to count bytes in")
         self.parser.add_argument("-l", nargs='?', const="-", default=None, help="File to count lines in")
+        self.parser.add_argument("-w", nargs='?', const="-", default=None, help="File to count lines in")
 
     def parse_args(self):
         args = self.parser.parse_args()
@@ -60,6 +75,12 @@ class CLI:
                 line_counter = LineCounter()
                 total_lines = line_counter.count(args.l)
                 print(f"Number of lines: {total_lines}")
+
+        if arg_provided_by_user:
+            if args.w is not None:
+                word_counter = WordCounter()
+                total_words = word_counter.count(args.w)
+                print(f"Number of lines: {total_words}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description:
- This commit introduces the WordCounter class, which extends the abstract Counter class, allowing us to count the number of words in a given file. 
- It includes argument parsing to accept user input for counting words.
- The WordCounter class provides a count method that reads the test_file and counts the number of words using Python's built-in split() function. 
- The CLI class now supports the command line option `-w` that outputs the number of words in a file.

- To count the words in a file, the user can now execute the script with the -w option followed by the file path. For example:

`python ccwc.py -w test.txt`

**Output:**

![image](https://github.com/Ebi27/ccwc-unix/assets/94403217/53a27a08-ab34-4886-81f0-2e836549ff14)

Finally, by combining the `LineCounter`, `ByteCounter`, and `WordCounter` classes with argument parsing, this commit enhances the tool's functionality and usability, enabling the user to choose the specific count they want for a given file.

